### PR TITLE
Ensure Zenzai delete HUD runs on main thread

### DIFF
--- a/ios/Packages/HamsteriOS/Sources/ViewModel/InputSchema/InputSchemaViewModel.swift
+++ b/ios/Packages/HamsteriOS/Sources/ViewModel/InputSchema/InputSchemaViewModel.swift
@@ -645,7 +645,9 @@ public class InputSchemaViewModel {
 
   /// 删除 Zenzai 模型文件
   func deleteZenzaiModel() async {
-    ProgressHUD.animate("删除中……", interaction: false)
+    await MainActor.run {
+      ProgressHUD.animate("删除中……", interaction: false)
+    }
     do {
       let fm = FileManager.default
       let zenzaiDir = FileManager.appGroupAzooKeyZenzaiDirectoryURL


### PR DESCRIPTION
### Motivation
- Ensure UI updates from `deleteZenzaiModel()` happen on the main thread to avoid potential UI race or consistency issues when showing/hiding `ProgressHUD`.

### Description
- Wrap the initial `ProgressHUD.animate("删除中……", interaction: false)` call in `await MainActor.run { ... }` inside `deleteZenzaiModel()` in `ios/Packages/HamsteriOS/Sources/ViewModel/InputSchema/InputSchemaViewModel.swift`.
- Existing `ProgressHUD.success` and `ProgressHUD.failed` calls in the same method were already executed on `MainActor` and remain unchanged.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69745f7f7dc8832a92db5dd0bbc787f1)